### PR TITLE
[WIP] Added decorator for injecting custom repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm-typedi-extensions",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Dependancy injection and service container integration with TypeORM using typedi library.",
   "license": "MIT",
   "readmeFilename": "README.md",
@@ -42,7 +42,7 @@
     "@types/node": "^7.0.4"
   },
   "peerDependencies": {
-    "typeorm": "^0.0.8",
+    "typeorm": "^0.0.9",
     "typedi": "^0.4.2"
   }
 }

--- a/src/decorators/OrmCustomRepository.ts
+++ b/src/decorators/OrmCustomRepository.ts
@@ -1,0 +1,27 @@
+import { ConnectionManager } from "typeorm";
+import { Container } from "typedi";
+
+/**
+ * Allows to inject a Repository using typedi's Container.
+ */
+export function OrmCustomRepository(cls: Function, connectionName: string = "default"): Function {
+    return function(target: Object|Function, propertyName: string, index?: number) {
+
+        const getValue = () => {
+            const connectionManager = Container.get(ConnectionManager);
+            if (!connectionManager.has(connectionName))
+                throw new Error(`Cannot get connection "${connectionName}" from the connection manager. ` +
+                    `Make sure you have created such connection. Also make sure you have called useContainer(Container) ` +
+                    `in your application before you established a connection and importing any entity.`);
+
+            const connection = connectionManager.get(connectionName);
+            return connection.getCustomRepository(cls as any);
+        };
+
+        if (index !== undefined) {
+            Container.registerParamHandler({ type: target as Function, index: index, getValue: getValue });
+        } else {
+            Container.registerPropertyHandler({ target: target as Function /* todo: looks like typedi wrong type here */, key: propertyName, getValue: getValue });
+        }
+    };
+}

--- a/src/decorators/OrmCustomRepository.ts
+++ b/src/decorators/OrmCustomRepository.ts
@@ -2,7 +2,8 @@ import { ConnectionManager } from "typeorm";
 import { Container } from "typedi";
 
 /**
- * Allows to inject a Repository using typedi's Container.
+ * Allows to inject a custom Repository using typedi's Container.
+ * Use it to get the repository class decorated with @EntityRepository decorator.
  */
 export function OrmCustomRepository(cls: Function, connectionName: string = "default"): Function {
     return function(target: Object|Function, propertyName: string, index?: number) {

--- a/src/decorators/OrmRepository.ts
+++ b/src/decorators/OrmRepository.ts
@@ -3,6 +3,7 @@ import {Container} from "typedi";
 
 /**
  * Allows to inject a Repository using typedi's Container.
+ * If you want to inject custom Repository class decorated with @EntityRepository decorator, use OrmCustomRepository instead.
  */
 export function OrmRepository(cls: Function, connectionName: string = "default"): Function {
     return function(target: Object|Function, propertyName: string, index?: number) {


### PR DESCRIPTION
When extending `Repository<T>` with `@EntityRepository(U)` decorator, you can't use it with routing-controllers - normal `@Service` injections doesn't have Connection metadata and `@OrmRepository` can't find the custom repository.