### PR TITLE
Allow to infer the custom repository type from param metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,18 +178,32 @@ export class PostService {
 
     // using constructor injection
     constructor(
-        @OrmCustomRepository(UserRepository)
+        @OrmCustomRepository()
         private readonly userRepository: UserRepository
     )
 
     public userExist(user: User): boolean {
-        return this.userRepository.findByEmail(user.email) ? true : false;
+        return this.userRepository.findByEmail(user.email)
+            ? true 
+            : false;
     }
 
 }
 ```
 
-Optionally, you can specify a connection name in the decorator parameters.
+Optionally, you can specify a custom repository class and/or connection name in the decorator parameters:
+```typescript
+@Service()
+export class PostService {
+    constructor(
+        @OrmCustomRepository("my-connection-name")
+        private readonly userRepository: UserRepository
+
+        @OrmCustomRepository(PhotoRepository)
+        private readonly photoRepository: IRepository<Photo>
+    )
+}
+```
 
 ### @OrmTreeRepository
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,19 @@
 {
   "name": "typeorm-typedi-extensions",
-  "version": "0.0.12",
-  "description": "Dependancy injection and service container integration with TypeORM using typedi library.",
+  "version": "0.0.13",
+  "description": "Dependency injection and service container integration with TypeORM using typedi library.",
   "license": "MIT",
   "readmeFilename": "README.md",
   "author": {
     "name": "Umed Khudoiberdiev",
     "email": "pleerock.me@gmail.com"
   },
+  "contributors": [
+    {
+      "name": "Michał Lytek",
+      "url": "https://github.com/19majkel94"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/typeorm/typeorm-typedi-extensions.git"

--- a/src/decorators/OrmCustomRepository.ts
+++ b/src/decorators/OrmCustomRepository.ts
@@ -5,17 +5,63 @@ import { Container } from "typedi";
  * Allows to inject a custom Repository using typedi's Container.
  * Use it to get the repository class decorated with @EntityRepository decorator.
  */
-export function OrmCustomRepository(cls: Function, connectionName: string = "default"): Function {
-    return function(object: Object|Function, propertyName: string, index?: number) {
-        Container.registerHandler({ object, index, propertyName, value: () => {
-            const connectionManager = Container.get(ConnectionManager);
-            if (!connectionManager.has(connectionName))
-                throw new Error(`Cannot get connection "${connectionName}" from the connection manager. ` +
-                  `Make sure you have created such connection. Also make sure you have called useContainer(Container) ` +
-                  `in your application before you established a connection and importing any entity.`);
+export function OrmCustomRepository(): ParameterDecorator;
+/**
+ * Allows to inject a custom Repository using typedi's Container.
+ * Use it to get the repository class decorated with @EntityRepository decorator.
+ */
+export function OrmCustomRepository(connectionName: string): ParameterDecorator;
+/**
+ * Allows to inject a custom Repository using typedi's Container.
+ * Use it to get the repository class decorated with @EntityRepository decorator.
+ */
+export function OrmCustomRepository(className: Function, connectionName?: string): ParameterDecorator;
 
-            const connection = connectionManager.get(connectionName);
-            return connection.getCustomRepository(cls as any);
-        }});
+export function OrmCustomRepository(classNameOrConnectionName?: Function|string, connectionName?: string): ParameterDecorator {
+    return (target, propertyKey, parameterIndex) => {
+        let clsName: Function;
+        let conName = "default";
+
+        // parse overloaded parameters
+        if (typeof classNameOrConnectionName === "string") {
+            conName = classNameOrConnectionName;
+        } else if (typeof classNameOrConnectionName === "function") {
+            clsName = classNameOrConnectionName;
+            if (connectionName) {
+                conName = connectionName;
+            }
+        }
+
+        // get reflected param type
+        if (!clsName) {
+            try {
+                clsName = Reflect.getOwnMetadata("design:paramtypes", target, propertyKey)[parameterIndex];
+            } catch (err) {
+                throw new Error(
+                    `Cannot get reflected type for "${propertyKey}" parameter of ${target.constructor.name} class. ` +
+                    `Make sure you have turned on an "emitDecoratorMetadata": true, option in tsconfig.json. ` +
+                    `Also make sure you have imported "reflect-metadata" on top of the main entry file in your application.`
+                );
+            }
+        }
+        
+        // register new handler for injection
+        Container.registerHandler({
+            object: target,
+            index: parameterIndex,
+            propertyName: propertyKey as string,
+            value: () => {
+                const connectionManager = Container.get(ConnectionManager);
+                if (!connectionManager.has(conName))
+                    throw new Error(
+                        `Cannot get connection "${conName}" from the connection manager. ` +
+                        `Make sure you have created such connection. Also make sure you have called useContainer(Container) ` +
+                        `in your application before you established a connection and importing any entity.`
+                    );
+
+                const connection = connectionManager.get(conName);
+                return connection.getCustomRepository(clsName);
+            }
+        });
     };
 }


### PR DESCRIPTION
This PR allows `@CustomRepository` decorator to get rid of duplicated type annotation in decorator parameter. It will try to use design metadata if not specified explicitly.

```ts
@Service()
export class PostService {
    constructor(
        @OrmCustomRepository() // <--- get repository type from param metadata
        private readonly userRepository: UserRepository
    )

    public userExist(user: User): boolean {
        return this.userRepository.findByEmail(user.email)
            ? true 
            : false;
    }
}

@Service()
export class PostService {
    constructor(
        @OrmCustomRepository("my-connection-name") // <--- specify connection name
        private readonly userRepository: UserRepository

        @OrmCustomRepository(PhotoRepository) // <--- or class type (eg. when using interfaces)
        private readonly photoRepository: IRepository<Photo>
    )
}
```