### PR TITLE
Set ConnectionManager as global in Container

### DIFF
--- a/src/container-registrations.const.ts
+++ b/src/container-registrations.const.ts
@@ -7,4 +7,4 @@ import { ConnectionManager } from 'typeorm';
  * We need to set imported TypeORM classes before requesting them, otherwise we
  * would receive a "ServiceNotFoundError" above TypeDI 0.9.1 from the decorators.
  */
-Container.set({ id: ConnectionManager, type: ConnectionManager });
+Container.set({ id: ConnectionManager, type: ConnectionManager, global: true });


### PR DESCRIPTION
Fixes scoped containerInstance.get requests for ConnectionManager, which was previously creating a cloned ConnectionManager via new ConnectionManager(), thereby removing all prior connection information.